### PR TITLE
Fixes bugs found when trying to do auth

### DIFF
--- a/django_coreapi/client.py
+++ b/django_coreapi/client.py
@@ -16,7 +16,7 @@ class DjangoCoreAPIClient(Client):
     def __init__(self, decoders=None, transports=None):
         if not transports:
             transports = [DjangoTestHTTPTransport()]
-        super().__init__(decoders, transports)
+        super(DjangoCoreAPIClient, self).__init__(decoders, transports)
 
     def get(self, url):
         url = _make_absolute(url)

--- a/django_coreapi/client.py
+++ b/django_coreapi/client.py
@@ -1,25 +1,22 @@
 from coreapi import Client
 from coreapi.client import _lookup_link
-from coreapi.codecs import default_decoders
 from coreapi.compat import string_types
 from coreapi.document import Link
 from coreapi.transports import determine_transport
 from django_coreapi.transports import DjangoTestHTTPTransport
-import itypes
 
 
 def _make_absolute(url):
     if not url.startswith('http'):
-        url = 'http://testserver/' + url.rstrip('/')
+        url = 'http://testserver/' + url.lstrip('/')
     return url
 
 
 class DjangoCoreAPIClient(Client):
-    def __init__(self, decoders=None):
-        if decoders is None:
-            decoders = default_decoders
-        self._decoders = itypes.List(decoders)
-        self._transports = itypes.List([DjangoTestHTTPTransport()])
+    def __init__(self, decoders=None, transports=None):
+        if not transports:
+            transports = [DjangoTestHTTPTransport()]
+        super().__init__(decoders, transports)
 
     def get(self, url):
         url = _make_absolute(url)

--- a/django_coreapi/transports.py
+++ b/django_coreapi/transports.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from coreapi.codecs import default_decoders
 from coreapi.document import Document, Object, Link, Array, Error
 from coreapi.transports.http import (
-    HTTPTransport, negotiate_decoder, Error, ErrorMessage
+    HTTPTransport, negotiate_decoder, ErrorMessage
 )
 from rest_framework.test import APIClient
 import json
@@ -84,7 +84,7 @@ def _get_headers(url, decoders=None, credentials=None):
         if host in credentials:
             headers['authorization'] = credentials[host]
 
-    return headers 
+    return headers
 
 
 def _handle_inplace_replacements(document, link, link_ancestors):
@@ -199,6 +199,7 @@ class DjangoTestHTTPTransport(HTTPTransport):
         path_params, query_params, body_params, header_params = _separate_params(method, link.fields, params)
         url = _expand_path_params(link.url, path_params)
         headers = _get_headers(url, decoders, self.credentials)
+        headers.update(self.headers)
         response = _make_http_request_with_test_client(url, method, headers, query_params, body_params)
         result = _decode_result_from_test_client(response, decoders, url)
 

--- a/test_app.py
+++ b/test_app.py
@@ -14,12 +14,12 @@ def document(request):
 @api_view(['GET'])
 @renderer_classes([CoreAPIJSONRenderer])
 def headers(request):
-    if not request.META.get('Authorization'):
+    if not request.META.get('HTTP_AUTHORIZATION'):
         raise Exception('Missing header')
     return Response(Document(title='Test Document', url='/'))
 
 
 urlpatterns = [
+    url(r'^headers/$', headers),
     url('', document),
-    url('/headers/', headers)
 ]

--- a/test_app.py
+++ b/test_app.py
@@ -11,6 +11,15 @@ def document(request):
     return Response(Document(title='Test Document', url='/'))
 
 
+@api_view(['GET'])
+@renderer_classes([CoreAPIJSONRenderer])
+def headers(request):
+    if not request.META.get('Authorization'):
+        raise Exception('Missing header')
+    return Response(Document(title='Test Document', url='/'))
+
+
 urlpatterns = [
     url('', document),
+    url('/headers/', headers)
 ]

--- a/tests.py
+++ b/tests.py
@@ -14,7 +14,6 @@ class Tests(unittest.TestCase):
         self.assertIsNotNone(doc)
 
     def test_client_headers(self):
-        client = DjangoCoreAPIClient()
         transport = DjangoTestHTTPTransport(headers={'authorization': 'token'})
         client = DjangoCoreAPIClient(transports=[transport])
         doc = client.get('/headers/')

--- a/tests.py
+++ b/tests.py
@@ -16,6 +16,6 @@ class Tests(unittest.TestCase):
     def test_client_headers(self):
         client = DjangoCoreAPIClient()
         transport = DjangoTestHTTPTransport(headers={'authorization': 'token'})
-        self.client = DjangoCoreAPIClient(transports=[transport])
+        client = DjangoCoreAPIClient(transports=[transport])
         doc = client.get('/headers/')
         self.assertIsNotNone(doc)

--- a/tests.py
+++ b/tests.py
@@ -4,10 +4,18 @@ settings.configure(ROOT_URLCONF='test_app', DEBUG=True, REST_FRAMEWORK={'UNAUTHE
 import django
 django.setup()
 from django_coreapi.client import DjangoCoreAPIClient
+from django_coreapi.transports import DjangoTestHTTPTransport
 
 
 class Tests(unittest.TestCase):
     def test_client(self):
         client = DjangoCoreAPIClient()
         doc = client.get('/')
+        self.assertIsNotNone(doc)
+
+    def test_client_headers(self):
+        client = DjangoCoreAPIClient()
+        transport = DjangoTestHTTPTransport(headers={'authorization': 'token'})
+        self.client = DjangoCoreAPIClient(transports=[transport])
+        doc = client.get('/headers/')
         self.assertIsNotNone(doc)


### PR DESCRIPTION
Fix so the following will work:

```
token = Token.objects.create(user=self.user)
transport = DjangoTestHTTPTransport(headers={'authorization': 'Token %s' % token.key})
self.client = DjangoCoreAPIClient(transports=[transport])
self.schema = self.client.get(reverse('schema'))
```
